### PR TITLE
[sunjung] feat: 대시보드 토글에 대시 컴포넌트 연결, 하드코딩 된 사용자 아이디 값 제거

### DIFF
--- a/src/features/recommend/component/chat/MessageBubble.css
+++ b/src/features/recommend/component/chat/MessageBubble.css
@@ -188,3 +188,32 @@ TODO : 현재는 그라데이션 색상인데, 나름 이쁜거 같아서 어떻
 .product-btn:active {
   transform: translateY(0);
 }
+
+/* QuickButton 메시지 버블 스타일 */
+.message-bubble.quickbutton {
+  padding: 0;
+  overflow: hidden;
+  max-width: 280px;
+}
+
+.message-quick-button {
+  width: 100% !important;
+  max-width: none !important;
+  margin: 0 !important;
+}
+
+.message-quick-button .quick-button-title {
+  font-size: 12px !important;
+  font-weight: 600;
+}
+
+.message-quick-button .quick-button-content {
+  font-size: 10px !important;
+  color: #666 !important;
+  margin-top: 2px;
+}
+
+.message-quick-button .quick-button-title-icon {
+  width: 16px !important;
+  height: 16px !important;
+}

--- a/src/features/recommend/component/chat/MessageBubble.jsx
+++ b/src/features/recommend/component/chat/MessageBubble.jsx
@@ -1,9 +1,14 @@
 import ProfileAvatar from './ProfileAvatar.jsx';
 import chatProfile from '../../../../shared/assets/img/chat_profile.png';
 import { useTypingEffect } from '../../hooks/useTypingEffect.js';
+import QuickButton from '../../../home/component/QuickButton';
+import checkIn from '../../../../shared/assets/img/checkin.png';
+import arrowIcon from '../../../../shared/assets/img/arrow.png';
+import { useNavigate } from 'react-router-dom';
 import './MessageBubble.css';
 
 const MessageBubble = ({ message, isAnimating = true, enableTyping = false, onTypingComplete, hideProfile = false }) => {
+  const navigate = useNavigate();
   const shouldUseTyping = enableTyping && message.sender === 'bot' && message.type === 'text';
 
   const { displayedText, isTyping } = useTypingEffect(
@@ -48,6 +53,18 @@ const MessageBubble = ({ message, isAnimating = true, enableTyping = false, onTy
               )}
             </div>
           </div>
+        );
+
+      case 'quickbutton':
+        return (
+          <QuickButton
+            titleIcon={checkIn}
+            title="오굿 리포트"
+            content="| 나의 리포트 확인하기"
+            icon={arrowIcon}
+            onClick={() => navigate("/dashboard")}
+            className="message-quick-button"
+          />
         );
 
       case 'text':

--- a/src/shared/store/chatStore.js
+++ b/src/shared/store/chatStore.js
@@ -188,6 +188,21 @@ export const useChatStore = create((set, get) => ({
 
     if (isLoading) return;
 
+    // "내 리포트 보기" 클릭 시 QuickButton 메시지 버블 추가
+    if (option === "내 리포트 보기") {
+      // QuickButton 메시지 추가
+      const quickButtonMessageId = generateMessageId();
+      const quickButtonMessage = {
+        id: quickButtonMessageId,
+        type: 'quickbutton',
+        sender: 'bot',
+        timestamp: new Date(),
+        isTyping: false
+      };
+      addMessage(quickButtonMessage);
+      return;
+    }
+
     // 로딩 상태 시작
     set({ isLoading: true, activeToggle: option });
 

--- a/src/shared/store/chatStore.js
+++ b/src/shared/store/chatStore.js
@@ -16,8 +16,6 @@ export const useChatStore = create((set, get) => ({
   pendingToggleOptions: null, // 타이핑 완료 후 적용할 토글 옵션
   pendingFlow: null, // 타이핑 완료 후 적용할 플로우
 
-  // API 관련 상태 - 지금은 id가 1로 고정
-  customerId: 1,
   sessionId: null,
 
   // SSE 관련 상태
@@ -82,7 +80,7 @@ export const useChatStore = create((set, get) => ({
 
   // 메시지 전송 처리
   handleSendMessage: async () => {
-    const { inputValue, addMessage, removeLoadingMessages, setCurrentTypingId, customerId, sessionId, isLoading } = get();
+    const { inputValue, addMessage, removeLoadingMessages, setCurrentTypingId, sessionId, isLoading } = get();
 
     if (!inputValue.trim() || isLoading) return;
 
@@ -111,7 +109,7 @@ export const useChatStore = create((set, get) => ({
 
     try {
       // API 요청 데이터 포맷팅
-      const apiRequest = formatMessageForAPI(inputValue, customerId, currentSessionId);
+      const apiRequest = formatMessageForAPI(inputValue, currentSessionId);
 
       // API 호출
       const response = await chatApi.sendChatMessage(apiRequest);
@@ -184,7 +182,7 @@ export const useChatStore = create((set, get) => ({
 
   // 토글 버튼 클릭
   handleToggleClick: async (option) => {
-    const { addMessage, removeLoadingMessages, setCurrentTypingId, customerId, sessionId, isLoading } = get();
+    const { addMessage, removeLoadingMessages, setCurrentTypingId, sessionId, isLoading } = get();
 
     if (isLoading) return;
 
@@ -218,7 +216,7 @@ export const useChatStore = create((set, get) => ({
 
     try {
       // API 요청 데이터 포맷팅 (토글 선택값을 inputMessage로 전송)
-      const apiRequest = formatMessageForAPI(option, customerId, sessionId);
+      const apiRequest = formatMessageForAPI(option, sessionId);
 
       // API 호출
       const response = await chatApi.sendChatMessage(apiRequest);
@@ -303,7 +301,7 @@ export const useChatStore = create((set, get) => ({
 
   // 초기 채팅 시작 (첫 진입시 호출)
   initializeChat: async () => {
-    const { addMessage, removeLoadingMessages, setCurrentTypingId, customerId, sessionId, isLoading } = get();
+    const { addMessage, removeLoadingMessages, setCurrentTypingId, sessionId, isLoading } = get();
 
     // 이미 메시지가 있거나 로딩 중이면 초기화하지 않음
     if (get().messages.length > 0 || isLoading) return;
@@ -325,7 +323,7 @@ export const useChatStore = create((set, get) => ({
       addMessage(loadingMessage);
 
       // 초기 API 요청 (빈 메시지)
-      const apiRequest = formatMessageForAPI("", customerId, currentSessionId);
+      const apiRequest = formatMessageForAPI("", currentSessionId);
 
       console.log('초기 채팅 시작:', apiRequest);
 
@@ -398,60 +396,4 @@ export const useChatStore = create((set, get) => ({
       addMessage(errorMessage);
     }
   },
-
-  // // SSE 연결 관리
-  // // SSE 연결
-  // connectSSE: (url) => {
-  //   const { eventSource } = get();
-  //
-  //   if (eventSource) {
-  //     eventSource.close();
-  //   }
-  //
-  //   const newEventSource = new EventSource(url);
-  //
-  //   newEventSource.onopen = () => {
-  //     set({ connectionStatus: 'connected' });
-  //   };
-  //
-  //   newEventSource.onerror = () => {
-  //     set({ connectionStatus: 'error' });
-  //   };
-  //
-  //   set({
-  //     sseUrl: url,
-  //     eventSource: newEventSource
-  //   });
-  // },
-  //
-  // // SSE 해제
-  // disconnectSSE: () => {
-  //   const { eventSource } = get();
-  //
-  //   if (eventSource) {
-  //     eventSource.close();
-  //     set({
-  //       eventSource: null,
-  //       connectionStatus: 'disconnected',
-  //       sseUrl: null
-  //     });
-  //   }
-  // },
-  //
-  // // SSE 메시지 처리
-  // handleSSEMessage: (messageId, data) => {
-  //   const { updateMessage } = get();
-  //
-  //   if (data.type === 'text_chunk') {
-  //     updateMessage(messageId, (prev) => ({
-  //       text: prev.text + data.content
-  //     }));
-  //   } else if (data.type === 'complete') {
-  //     updateMessage(messageId, {
-  //       isTyping: false,
-  //       isComplete: true
-  //     });
-  //     set({ currentTypingId: null });
-  //   }
-  // }
 }));

--- a/src/shared/utils/messageUtils.js
+++ b/src/shared/utils/messageUtils.js
@@ -6,9 +6,8 @@ export const generateMessageId = () => {
 };
 
 // 메시지 데이터 포맷팅 (API 전송용)
-export const formatMessageForAPI = (message, customerId = 1, sessionId = null) => {
+export const formatMessageForAPI = (message, sessionId = null) => {
   return {
-    customerId: customerId,
     sessionId: sessionId || generateSessionId(),
     inputMessage: message || ""
   };


### PR DESCRIPTION
## 📌 PR 종류

## 해당 되는 곳에 x 를 넣어주세요 [ ] -> [x]

- [x] feat: 새로운 기능 추가
- [ ] fix: 버그 수정
- [ ] docs: 문서 수정
- [ ] style: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [ ] refactor: 코드 리팩토링
- [ ] test: 테스트 코드 추가 또는 수정
- [ ] chore: 빌드 업무 수정, 패키지 매니저 수정 등

---

## ✨ 작업 내용

- 대시보드 토글에 컴포넌트 연결
- 하드코딩 값 제거, jwt 이용

---

## ✅ 작업 상세 내용

- 대시보드 토글에 컴포넌트 연결했습니다. 라우팅까지 확인 완료
- 하드코딩된 id값 제거하고 jwt 사용하도록 바꿨습니다.

---

## 🔍 기타 참고사항

- X

---

## 📸 스크린샷

<img width="264" height="220" alt="image" src="https://github.com/user-attachments/assets/e3903423-ffde-4a4f-b8d7-1d2453bc3411" />

메세지 버블에 연결되는 컴포넌트는 메인에 있는것과 똑같이 생겼습니당 크기만 달라요
